### PR TITLE
Code eval error handling

### DIFF
--- a/backend/chromeApiServer/pom.xml
+++ b/backend/chromeApiServer/pom.xml
@@ -80,6 +80,10 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
 
 
     </dependencies>

--- a/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java
@@ -58,7 +58,7 @@ public class ChromeApiController {
         String userId = canvasClientService.fetchUserId(bearerToken);
 
         // Create the user with the params
-        ExtensionUser user = new ExtensionUser(bearerToken, userId, courseId, assignmentId, studentId, UserType.GRADER);
+        ExtensionUser user = new ExtensionUser(bearerToken, userId, courseId, assignmentId, studentId, type);
 
         return evaluation.executeCodeFile(user);
 

--- a/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java
@@ -1,17 +1,16 @@
 package com.canvas.controllers.chromeApiServer;
 
+import com.canvas.exceptions.UserNotAuthorizedException;
 import com.canvas.service.EvaluationService;
 import com.canvas.service.models.CommandOutput;
 import com.canvas.service.helperServices.CanvasClientService;
 import com.canvas.service.models.ExtensionUser;
 import com.canvas.service.models.UserType;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 
@@ -48,17 +47,18 @@ public class ChromeApiController {
             @PathVariable("courseId") String courseId,
             @PathVariable("studentId") String studentId,
             @RequestParam("userType") UserType type
-    ) throws IOException {
+    ) throws IOException, UserNotAuthorizedException {
         // check userType isn't Unauthorized or Student
         if (type == UserType.UNAUTHORIZED || type == UserType.STUDENT) {
-            System.out.println(String.format("Exception: user type does not match expected [%s]", UserType.GRADER));
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            String errorMessage = String.format("user type [%s] does not match expected [%s]", type, UserType.GRADER);
+            System.out.println(errorMessage); // TODO use spring boot logger for printing messages to console
+            throw new UserNotAuthorizedException(errorMessage);
         }
         // get the user id from the Canvas API
         String userId = canvasClientService.fetchUserId(bearerToken);
 
         // Create the user with the params
-        ExtensionUser user = new ExtensionUser(bearerToken, userId, courseId, assignmentId, studentId, type);
+        ExtensionUser user = new ExtensionUser(bearerToken, userId, courseId, assignmentId, studentId, UserType.GRADER);
 
         return evaluation.executeCodeFile(user);
 
@@ -81,17 +81,18 @@ public class ChromeApiController {
             produces = {"application/json"}, //This method should only start the program and return a success response
             consumes = {"multipart/form-data"}
     )
-    public ResponseEntity<CommandOutput> initiateStudentCodeEvaluation(
+    public ResponseEntity<?> initiateStudentCodeEvaluation(
             @RequestHeader("Authorization") String bearerToken,
             @RequestParam("files") MultipartFile[] files,
             @RequestParam("assignmentId") String assignmentId,
             @RequestParam("courseId") String courseId,
             @RequestParam("userType") UserType type
-    ) throws IOException {
+    ) throws IOException, UserNotAuthorizedException {
         // check userType isn't Unauthorized or Grader
         if (type == UserType.UNAUTHORIZED || type == UserType.GRADER) {
-            System.out.println(String.format("Exception: user type does not match expected [%s]", UserType.STUDENT));
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            String errorMessage = String.format("user type [%s] does not match expected [%s]", type, UserType.STUDENT);
+            System.out.println(errorMessage); // TODO use spring boot logger for printing messages to console
+            throw new UserNotAuthorizedException(errorMessage);
         }
 
         // Get the user id from Canvas API

--- a/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java
@@ -81,7 +81,7 @@ public class ChromeApiController {
             produces = {"application/json"}, //This method should only start the program and return a success response
             consumes = {"multipart/form-data"}
     )
-    public ResponseEntity<?> initiateStudentCodeEvaluation(
+    public ResponseEntity<CommandOutput> initiateStudentCodeEvaluation(
             @RequestHeader("Authorization") String bearerToken,
             @RequestParam("files") MultipartFile[] files,
             @RequestParam("assignmentId") String assignmentId,

--- a/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiServerApplication.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiServerApplication.java
@@ -1,11 +1,14 @@
 package com.canvas.controllers.chromeApiServer;
 
+import com.canvas.exceptions.handler.ControllerExceptionHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {"com.canvas.controllers.chromeApiServer", "com.canvas.service"})
+@Import(ControllerExceptionHandler.class)
 public class ChromeApiServerApplication {
 
 	public static void main(String[] args) {

--- a/backend/chromeApiServer/src/main/java/com/canvas/exceptions/UserNotAuthorizedException.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/exceptions/UserNotAuthorizedException.java
@@ -1,0 +1,17 @@
+package com.canvas.exceptions;
+
+import java.io.Serial;
+
+public class UserNotAuthorizedException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public UserNotAuthorizedException() {
+        super();
+    }
+
+    public UserNotAuthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ControllerExceptionHandler.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ControllerExceptionHandler.java
@@ -7,6 +7,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+/**
+ * Exceptions that are thrown in the controller will get redirected to methods in this class. To redirect
+ * exception handling to a specific method, the @ExceptionHandler annotation is added with the exception
+ * that it handles.
+ */
 @ControllerAdvice
 public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
 

--- a/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ControllerExceptionHandler.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ControllerExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.canvas.exceptions.handler;
+
+import com.canvas.exceptions.UserNotAuthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(UserNotAuthorizedException.class)
+    protected ResponseEntity<ErrorResponse> handleUserNotAuthorizedException(
+            UserNotAuthorizedException exception
+    ) {
+        return buildErrorResponse(exception);
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(UserNotAuthorizedException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.UNAUTHORIZED, exception.getMessage());
+        return new ResponseEntity<>(errorResponse, errorResponse.getStatus());
+    }
+}

--- a/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ErrorResponse.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ErrorResponse.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.http.HttpStatus;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.Date;
 
+
+/**
+ * Error response object that will be seen by the client (as a JSON).
+ */
 @Getter
 @Setter
 public class ErrorResponse {

--- a/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ErrorResponse.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.canvas.exceptions.handler;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+@Getter
+@Setter
+public class ErrorResponse {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    private Date timestamp;
+
+    private int code;
+
+    private HttpStatus status;
+
+    private String message;
+
+    public ErrorResponse(HttpStatus httpStatus, String message) {
+        this.timestamp = new Date();
+        this.status = httpStatus;
+        this.code = httpStatus.value();
+        this.message = message;
+    }
+}

--- a/backend/chromeApiServer/src/test/java/com/canvas/controllers/chromeApiServer/ChromeApiControllerUnitTest.java
+++ b/backend/chromeApiServer/src/test/java/com/canvas/controllers/chromeApiServer/ChromeApiControllerUnitTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -117,14 +118,9 @@ class ChromeApiControllerUnitTest {
      */
     @ParameterizedTest
     @CsvFileSource(resources = "/chromeAPI_userType_instructor_tests.csv", numLinesToSkip = 1)
-    public void initiateInstructorCodeEvaluation_should_return_badRequest_with_wrong_userType(String userType) throws Exception {
+    public void initiateInstructorCodeEvaluation_should_return_badRequest_when_userType_not_valid_enum(String userType) throws Exception {
         // Set Up
         String authToken = "TestStringToken";
-        MockMultipartFile multipartFile = new MockMultipartFile("files", "test.txt",
-                "text/plain", "Spring Framework".getBytes());
-        String userID = "132546";
-        String assignmentID = "cs5461321";
-        String courseID = "cpsc5023";
         String type = userType;
 
         // Act
@@ -138,6 +134,26 @@ class ChromeApiControllerUnitTest {
 
         // Assert
         assertEquals(HttpStatus.BAD_REQUEST.value(), result.getResponse().getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UNAUTHORIZED", "STUDENT"})
+    public void initiateInstructorCodeEvaluation_should_return_unauthorized_when_userType_not_GRADER(String userType) throws Exception {
+        // Set Up
+        String authToken = "TestStringToken";
+        String type = userType;
+
+        // Act
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/execute/courses/cpsc5023/assignments/cs5461321/submissions/1235464")
+                        .header("Authorization", authToken)
+                        .param("userType", type)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())  // assert we get unauthorized response
+                .andReturn();
+
+        // Assert
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), result.getResponse().getStatus());
     }
 
     /**
@@ -184,7 +200,7 @@ class ChromeApiControllerUnitTest {
      */
     @ParameterizedTest
     @CsvFileSource(resources = "/chromeAPI_userType_student_tests.csv", numLinesToSkip = 1)
-    public void initiateStudentCodeEvaluation_should_return_badRequest_with_wrong_userType(String userType) throws Exception {
+    public void initiateStudentCodeEvaluation_should_return_badRequest_when_userType_not_valid_enum(String userType) throws Exception {
         // Set Up
         String authToken = "TestStringToken";
         MockMultipartFile multipartFile = new MockMultipartFile("files", "test.txt",
@@ -208,6 +224,34 @@ class ChromeApiControllerUnitTest {
 
         // Assert
         assertEquals(HttpStatus.BAD_REQUEST.value(), result.getResponse().getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UNAUTHORIZED", "GRADER"})
+    public void initiateStudentCodeEvaluation_should_return_unauthorized_when_userType_not_STUDENT(String userType) throws Exception {
+        // Set Up
+        String authToken = "TestStringToken";
+        MockMultipartFile multipartFile = new MockMultipartFile("files", "test.txt",
+                "text/plain", "Spring Framework".getBytes());
+        String userID = "132546";
+        String assignmentID = "cs5461321";
+        String courseID = "cpsc5023";
+        String type = userType;
+
+        // Act
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.multipart("/evaluate")
+                        .file(multipartFile)
+                        .header("Authorization", authToken)
+                        .param("assignmentId", assignmentID)
+                        .param("courseId", courseID)
+                        .param("userType", type)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())  // assert we get unauthorized response
+                .andReturn();
+
+        // Assert
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), result.getResponse().getStatus());
     }
 
 

--- a/backend/chromeApiServer/src/test/resources/chromeAPI_userType_instructor_tests.csv
+++ b/backend/chromeApiServer/src/test/resources/chromeAPI_userType_instructor_tests.csv
@@ -1,6 +1,4 @@
 userType
-UNAUTHORIZED
-STUDENT
 unauthorized
 student
 instructor

--- a/backend/chromeApiServer/src/test/resources/chromeAPI_userType_student_tests.csv
+++ b/backend/chromeApiServer/src/test/resources/chromeAPI_userType_student_tests.csv
@@ -1,6 +1,4 @@
 userType
-UNAUTHORIZED
-GRADER
 1654984
 unauthorized
 grader


### PR DESCRIPTION
Added more robust error handling:
- `backend/chromeApiServer/src/main/java/com/canvas/exceptions/UserNotAuthorizedException.java`: custom exception for unauthorized user
- `backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiController.java`: throws the `UserNotAuthorizedException`
- `backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ControllerExceptionHandler.java`: exception handler - when exception is thrown, the method annotated with the matching exception will be called
- `backend/chromeApiServer/src/main/java/com/canvas/controllers/chromeApiServer/ChromeApiServerApplication.java`: import annotation required for exception to be resolved by the handler
- `backend/chromeApiServer/src/main/java/com/canvas/exceptions/handler/ErrorResponse.java`: structure for the error response JSON seen by the client
- `backend/chromeApiServer/src/test/java/com/canvas/controllers/chromeApiServer/ChromeApiControllerUnitTest.java`: updated unit test methods to be more specific to when client passed an arbitrary String vs. a valid UserType enum