### PR TITLE
added utf-8 encoding config in pom.xml

### DIFF
--- a/backend/chromeApiServer/pom.xml
+++ b/backend/chromeApiServer/pom.xml
@@ -92,6 +92,10 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <executable>true</executable>
+                    <jvmArguments>-Dfile.encoding=UTF8</jvmArguments>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
There was some bug with the encoding of single quotes. Didn't catch it before because intellij did some magic to encode properly. Only spotted issue when running spring boot from the terminal