### PR TITLE
changed filename check to ignore casing in canvas file api call

### DIFF
--- a/backend/chromeApiServer/src/main/java/com/canvas/service/helperServices/CanvasClientService.java
+++ b/backend/chromeApiServer/src/main/java/com/canvas/service/helperServices/CanvasClientService.java
@@ -93,7 +93,7 @@ public class CanvasClientService {
                     .build();
 
             JsonNode filesResponse = parseResponseToJsonNode(this.okHttpClient.newCall(filesRequest).execute());
-            String fileId = getFileIdFromFilesResponse(filesResponse, fileName + ".dms");
+            String fileId = getFileIdFromFilesResponse(filesResponse, fileName);
             return fetchFile(fileId, user.getBearerToken());
         } catch (Exception e) {
             throw throwCanvasException(e);
@@ -395,8 +395,8 @@ public class CanvasClientService {
     protected String getFileIdFromFilesResponse(JsonNode response, String fileName) {
         for (Iterator<JsonNode> it = response.elements(); it.hasNext(); ) {
             JsonNode folder = it.next();
-            JsonNode name = folder.get("filename");
-            if (name != null && folder.get("filename").asText().equals(fileName)) {
+            JsonNode name = folder.get("display_name");
+            if (name != null && folder.get("display_name").asText().equalsIgnoreCase(fileName)) {
                 return folder.get("id").toString();
             }
         }

--- a/backend/chromeApiServer/src/test/java/com/canvas/service/helperServices/CanvasClientServiceTest.java
+++ b/backend/chromeApiServer/src/test/java/com/canvas/service/helperServices/CanvasClientServiceTest.java
@@ -55,7 +55,7 @@ class CanvasClientServiceTest {
             .message("")
             .body(ResponseBody.create(
                     MediaType.get("application/json; charset=utf-8"),
-                    "{\"id\":\"fooId\", \"assignment\": {\"filename\": \"fooAssignmentId.dms\", \"id\": 12345} }"
+                    "{\"id\":\"fooId\", \"assignment\": {\"display_name\": \"fooAssignmentId\", \"id\": 12345} }"
             ))
             .build();
 
@@ -447,7 +447,7 @@ class CanvasClientServiceTest {
 
         Assertions.assertEquals(
                 "12345",
-                canvasClientService.getFileId("folderId", "fooAssignmentId.dms", BEARER_TOKEN)
+                canvasClientService.getFileId("folderId", "fooAssignmentId", BEARER_TOKEN)
         );
     }
 


### PR DESCRIPTION
changed `equals` to `equalsIgnoreCase` so that backend can find "makefile" or "Makefile" from canvas API response