### PR TITLE
calling delete submission API from frontend

### DIFF
--- a/frontend/canvas-chrome-ext/src/scripts/instructor-inject-script.jsx
+++ b/frontend/canvas-chrome-ext/src/scripts/instructor-inject-script.jsx
@@ -106,8 +106,7 @@ function studentHasSubmission() {
 
 function getParameters(canvasUrl) {
     console.log(canvasUrl);
-
-    const urlSearchParamsObj = new URLSearchParams(window.location.search);
+    const urlSearchParamsObj = new URL(canvasUrl).searchParams;
     const queryParams = Object.fromEntries(urlSearchParamsObj.entries());
 
     console.log('query params: ' + queryParams);

--- a/frontend/canvas-chrome-ext/src/scripts/instructor-inject-script.jsx
+++ b/frontend/canvas-chrome-ext/src/scripts/instructor-inject-script.jsx
@@ -17,7 +17,7 @@ async function beginUrlChangeListener() {
         if (window.location.href !== previousUrl) {
             console.log(`URL changed from ${previousUrl} to ${window.location.href}`);
             if (!isFirstStudent) {
-                erasePreviousStudentView(previousUrl);
+                await erasePreviousStudentView(previousUrl);
             }
 
             previousUrl = window.location.href;


### PR DESCRIPTION
- `beginUrlChangeListener`: changed url listening scheme to ping every second, less error prone than MutationObserver
- `deletePreviousStudentSubmissionDirectory`: function to call the delete API
- `getParameters`: added canvasUrl parameter so that we can either pass in the current url or previous url (for deleting previous student submission)