### PR TITLE
remove trailing space from canvas.url in properties file

### DIFF
--- a/backend/chromeApiServer/src/main/resources/application-canvas.properties
+++ b/backend/chromeApiServer/src/main/resources/application-canvas.properties
@@ -1,6 +1,6 @@
 spring.main.allow-circular-references=true
 oauth.enabled=false
-canvas.url=https://canvas.instructure.com/api/v1 
+canvas.url=https://canvas.instructure.com/api/v1
 canvas.secretKey=NoSecret
 canvas.clientId=NoClientId
 canvas.clientSecret=NoClientSecret


### PR DESCRIPTION
minor fix to remove trailing space from canvas.url which was causing canvas API calls to fail